### PR TITLE
Fix the namespace used for SR-IOV helm chart

### DIFF
--- a/fleets/day2/chart-templates/sriov/sriov-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/sriov/sriov-crd/fleet.yaml
@@ -1,4 +1,4 @@
-defaultNamespace: kube-system
+defaultNamespace: sriov-network-operator
 
 helm:
   releaseName: sriov-crd-chart

--- a/fleets/day2/chart-templates/sriov/sriov-network-operator/fleet.yaml
+++ b/fleets/day2/chart-templates/sriov/sriov-network-operator/fleet.yaml
@@ -1,4 +1,4 @@
-defaultNamespace: kube-system
+defaultNamespace: sriov-network-operator
 
 helm:
   releaseName: sriov-network-operator-chart


### PR DESCRIPTION
Aligns better with the upstream chart install [instructions](https://github.com/suse-edge/charts/tree/main/charts/sriov-network-operator/1.2.4%2Bup0.1.0#deploy-sr-iov-network-operator).