### PR TITLE
Fix general fleet links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # fleet-examples
 
-* [Simple](./fleets/simple) a deployment + service (x86_64 & arm64)
+* [Simple](./fleets/general/simple) a deployment + service (x86_64 & arm64)
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/simple-gitrepo.yaml
 ```
 
-* [Akri](./fleets/akri) - [Akri](https://github.com/project-akri/akri) via [SUSE Edge charts repository](https://suse-edge.github.io/charts/)
+* [Akri](./fleets/general/akri) - [Akri](https://github.com/project-akri/akri) via [SUSE Edge charts repository](https://suse-edge.github.io/charts/)
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/akri-suse-edge-gitrepo.yaml
 ```
 
-* [Kubevirt](./fleets/kubevirt) - [Kubevirt](https://github.com/kubevirt/kubevirt) via [SUSE Edge charts repository](https://suse-edge.github.io/charts/)
+* [Kubevirt](./fleets/general/kubevirt) - [Kubevirt](https://github.com/kubevirt/kubevirt) via [SUSE Edge charts repository](https://suse-edge.github.io/charts/)
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/kubevirt-suse-edge-gitrepo.yaml
 ```
 
-* [MetalLB](./fleets/metallb) - [MetalLB](https://metallb.universe.tf/) via [Rancher Partner charts repository](https://github.com/rancher/partner-charts/)
+* [MetalLB](./fleets/general/metallb) - [MetalLB](https://metallb.universe.tf/) via [Rancher Partner charts repository](https://github.com/rancher/partner-charts/)
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/metallb-suse-edge-gitrepo.yaml
 ```
 
-* [Elemental](./fleets/elemental) - [Elemental Operator](https://github.com/rancher/elemental-operator), including the [Elemental's Rancher UI Plugin](https://github.com/rancher/ui-plugin-charts/):
+* [Elemental](./fleets/general/elemental) - [Elemental Operator](https://github.com/rancher/elemental-operator), including the [Elemental's Rancher UI Plugin](https://github.com/rancher/ui-plugin-charts/):
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/elemental-gitrepo.yaml
@@ -32,7 +32,7 @@ kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main
 
 NOTE: If the [Rancher's UI Plugin Operator](https://github.com/rancher/ui-plugin-operator) is not installed, enable the installation in the [Elemental Gitrepo](./gitrepos/general/elemental-gitrepo.yaml) file.
 
-* [Opni](./fleets/opni) - [Opni](https://github.com/rancher/opni), including the [Opni's Rancher UI Plugin](https://github.com/rancher/opni-ui/):
+* [Opni](./fleets/general/opni) - [Opni](https://github.com/rancher/opni), including the [Opni's Rancher UI Plugin](https://github.com/rancher/opni-ui/):
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/opni-gitrepo.yaml
@@ -40,13 +40,13 @@ kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main
 
 NOTE: If the [Rancher's UI Plugin Operator](https://github.com/rancher/ui-plugin-operator) is not installed, enable the installation in the [Opni Gitrepo](./gitrepos/general/opni-gitrepo.yaml) file.
 
-* [Rancher's UI Plugin Operator](./fleets/rancher-ui-plugin-operator) - [Rancher's UI Plugin Operator](https://github.com/rancher/ui-plugin-operator):
+* [Rancher's UI Plugin Operator](./fleets/general/rancher-ui-plugin-operator) - [Rancher's UI Plugin Operator](https://github.com/rancher/ui-plugin-operator):
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/rancher-ui-plugin-operator-gitrepo.yaml
 ```
 
-* [Longhorn](./fleets/longhorn) - [Longhorn](https://longhorn.io/):
+* [Longhorn](./fleets/general/longhorn) - [Longhorn](https://longhorn.io/):
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/suse-edge/fleet-examples/main/gitrepos/general/longhorn-gitrepo.yaml
@@ -83,7 +83,7 @@ ingress:
   host: "longhorn-example.com"
 ```
 
-You can modify the Longhorn's [fleet.yaml](./fleets/longhorn/fleet.yaml) file to fit your needs.
+You can modify the Longhorn's [fleet.yaml](./fleets/general/longhorn/longhorn/fleet.yaml) file to fit your needs.
 
 * You can configure Fleet to read Helm custom values in a configmap created somewhere in the cluster such as:
 
@@ -146,9 +146,9 @@ This means:
 
 `kubectl annotate clusters.fleet.cattle.io/local -n fleet-local  "ingressip=$(kubectl get svc -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"`
 
-It will enable the Longhorn UI protected via user/password using a [kustomization overlay](./fleets/longhorn/longhorn/overlays/kustomization.yaml)
+It will enable the Longhorn UI protected via user/password using a [kustomization overlay](./fleets/general/longhorn/longhorn/overlays/local/kustomization.yaml)
 
-This is basically intended to be used with the [create-vm.sh](../slemicro/create_vm.sh) script as:
+This is basically intended to be used with the [create-vm.sh](https://github.com/suse-edge/misc/tree/main/slemicro#create_vmsh) script as:
 
 ```
 ./create_vm.sh -f myvm


### PR DESCRIPTION
Fixes links to the general fleet links in the README in regards to the recent "Day 2" directory reorder.

closes: #13