### PR TITLE
Fix OS migration bug

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -134,24 +134,19 @@ spec:
               # Common Platform Enumeration (CPE) that the system is currently running with
               CURRENT_CPE=`cat /etc/os-release | grep -w CPE_NAME | cut -d "=" -f 2 | tr -d '"'`
 
-              # Lines that will be appended to the systemd.service 'ExecStartPre' configuration
-              EXEC_START_PRE_LINES=""
-
               # Determine whether this is a package update or a migration
               if [ "${EDGE_RELEASE_CPE}" == "${CURRENT_CPE}" ]; then
                   # Package update if both CPEs are the same
-                  EXEC_START="/usr/sbin/transactional-update cleanup up"
+                  EXEC_START="ExecStart=/usr/sbin/transactional-update cleanup up"
                   SERVICE_NAME="os-pkg-update.service"
               else
                   SYSTEM_ARCH=`arch`
                   FULLY_QUANTIFIED_PRODUCT=${SL_MICRO_ZYPPER_ID}/${SL_MICRO_VERSION}/${SYSTEM_ARCH}
 
-                  # Migration if the CPEs are different
-                  EXEC_START_PRE_PKG_UPGRADE="ExecStartPre=/usr/sbin/transactional-update cleanup up"
-                  EXEC_START_PRE_RPM_IMPORT="ExecStartPre=/usr/sbin/transactional-update --continue run rpm --import ${SL_MICRO_REPO_GPG_KEY_PATH}"
-                  EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}\n${EXEC_START_PRE_RPM_IMPORT}")
+                  PKG_UPDATE_CMD="ExecStart=/usr/sbin/transactional-update cleanup up"
+                  MIGRATION_CMD="ExecStart=/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product ${FULLY_QUANTIFIED_PRODUCT} --root /"
+                  EXEC_START=$(echo -e "${PKG_UPDATE_CMD}\n${MIGRATION_CMD}")
 
-                  EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --non-interactive --product ${FULLY_QUANTIFIED_PRODUCT} --root /"
                   SERVICE_NAME="os-migration.service"
               fi
 
@@ -171,10 +166,9 @@ spec:
 
           [Service]
           Type=oneshot
-          ${EXEC_START_PRE_LINES:+$EXEC_START_PRE_LINES
-          }ExecStart=${EXEC_START}
           IOSchedulingClass=best-effort
           IOSchedulingPriority=7
+          ${EXEC_START}
           EOF
 
               echo "Starting ${SERVICE_NAME}..."
@@ -214,7 +208,6 @@ spec:
         EDGE_RELEASE_CPE: "cpe:/o:suse:sl-micro:6.0"
         SL_MICRO_ZYPPER_ID: "SL-Micro"
         SL_MICRO_VERSION: "6.0"
-        SL_MICRO_REPO_GPG_KEY_PATH: "/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-645b99ce.asc"
     name: os-pkg-update-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/config-map.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/config-map.yaml
@@ -6,4 +6,3 @@ data:
   EDGE_RELEASE_CPE: "cpe:/o:suse:sl-micro:6.0"
   SL_MICRO_ZYPPER_ID: "SL-Micro"
   SL_MICRO_VERSION: "6.0"
-  SL_MICRO_REPO_GPG_KEY_PATH: "/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-645b99ce.asc"

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/secret.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/secret.yaml
@@ -30,24 +30,19 @@ stringData:
         # Common Platform Enumeration (CPE) that the system is currently running with
         CURRENT_CPE=`cat /etc/os-release | grep -w CPE_NAME | cut -d "=" -f 2 | tr -d '"'`
 
-        # Lines that will be appended to the systemd.service 'ExecStartPre' configuration
-        EXEC_START_PRE_LINES=""
-
         # Determine whether this is a package update or a migration
         if [ "${EDGE_RELEASE_CPE}" == "${CURRENT_CPE}" ]; then
             # Package update if both CPEs are the same
-            EXEC_START="/usr/sbin/transactional-update cleanup up"
+            EXEC_START="ExecStart=/usr/sbin/transactional-update cleanup up"
             SERVICE_NAME="os-pkg-update.service"
         else
             SYSTEM_ARCH=`arch`
             FULLY_QUANTIFIED_PRODUCT=${SL_MICRO_ZYPPER_ID}/${SL_MICRO_VERSION}/${SYSTEM_ARCH}
 
-            # Migration if the CPEs are different
-            EXEC_START_PRE_PKG_UPGRADE="ExecStartPre=/usr/sbin/transactional-update cleanup up"
-            EXEC_START_PRE_RPM_IMPORT="ExecStartPre=/usr/sbin/transactional-update --continue run rpm --import ${SL_MICRO_REPO_GPG_KEY_PATH}"
-            EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}\n${EXEC_START_PRE_RPM_IMPORT}")
+            PKG_UPDATE_CMD="ExecStart=/usr/sbin/transactional-update cleanup up"
+            MIGRATION_CMD="ExecStart=/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product ${FULLY_QUANTIFIED_PRODUCT} --root /"
+            EXEC_START=$(echo -e "${PKG_UPDATE_CMD}\n${MIGRATION_CMD}")
 
-            EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --non-interactive --product ${FULLY_QUANTIFIED_PRODUCT} --root /"
             SERVICE_NAME="os-migration.service"
         fi
 
@@ -67,10 +62,9 @@ stringData:
 
     [Service]
     Type=oneshot
-    ${EXEC_START_PRE_LINES:+$EXEC_START_PRE_LINES
-    }ExecStart=${EXEC_START}
     IOSchedulingClass=best-effort
     IOSchedulingPriority=7
+    ${EXEC_START}
     EOF
 
         echo "Starting ${SERVICE_NAME}..."


### PR DESCRIPTION
Currently OS migration hangs when there is a third-party repository added in zypper.

Since `suseconnect-ng` versions > 1.9 have been introduced, we can now utilise the `--gpg-auto-import-keys` flag which was previously broken.

Utilising this flag results in:
1. All repository keys being auto-imported. This means that the SL Micro 6.0 and any other third-party repository keys will be imported without us having to manually specify the path to the GPG keys.
2. Because of (1) we no longer need the logic around keeping the path of the SL Micro 6.0 repo GPG key

Key changes:
1. `SL_MICRO_REPO_GPG_KEY_PATH ` is no longer used.
2. Upgrade script logic was simplified and made to work correctly under a systemd.service type of `oneshot`.
3. Our migration command now utilises the `--gpg-auto-import-keys` flag, which significantly eases GPG key handling.

Example migration logs for a node that has the following 3 third-party repositories added:
```bash
zypper ar https://download.opensuse.org/repositories/SUSE:/CA/SLE_15_SP5 opensuse-ca
zypper ar https://download.nvidia.com/suse/sle15sp5/ nvidia
zypper ar https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/ cuda
```

```bash
Executing '/usr/bin/zypper --releasever 6.0 --gpg-auto-import-keys ref -f'

Warning: Enforced setting: $releasever=6.0
Forcing raw metadata refresh
Retrieving repository 'SL-Micro-6.0-Pool' metadata [......

Automatically importing the following key:

  Repository:       SL-Micro-6.0-Pool
  Key Fingerprint:  1C59 D66F CD52 563A 1693 3DBC FEC2 8EAF 09D9 EA69
  Key Name:         ALP Package Signing Key <build-alp@suse.de>
  Key Algorithm:    RSA 4096
  Key Created:      Wed May 10 13:19:10 2023
  Key Expires:      Sun May  9 13:19:10 2027
  Rpm Name:         gpg-pubkey-09d9ea69-645b99ce



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
.............done]
Forcing building of repository cache
Building repository 'SL-Micro-6.0-Pool' cache [....done]
Forcing raw metadata refresh
Retrieving repository 'cuda' metadata [....

Automatically importing the following key:

  Repository:       cuda
  Key Fingerprint:  610C 7B14 E068 A878 070D A4E9 9CD0 A493 D42D 0685
  Key Name:         cudatools <cudatools@nvidia.com>
  Key Algorithm:    RSA 4096
  Key Created:      Thu Apr 14 22:04:01 2022
  Key Expires:      (does not expire)
  Rpm Name:         gpg-pubkey-d42d0685-62589a51



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
..done]
Forcing building of repository cache
Building repository 'cuda' cache [....done]
Forcing raw metadata refresh
Retrieving repository 'nvidia' metadata [....

Automatically importing the following key:

  Repository:       nvidia
  Key Fingerprint:  2FB0 3195 DECD 4949 2BD1 C17A B1D0 D788 DB27 FD5A
  Key Name:         NVIDIA Linux Driver Team <linux-bugs@nvidia.com>
  Key Algorithm:    RSA 4096
  Key Created:      Thu Apr 14 22:04:01 2022
  Key Expires:      (does not expire)
  Rpm Name:         gpg-pubkey-db27fd5a-62589a51



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
..done]
Forcing building of repository cache
Building repository 'nvidia' cache [....done]
Forcing raw metadata refresh
Retrieving repository 'opensuse-ca' metadata [...........

Automatically importing the following key:

  Repository:       opensuse-ca
  Key Fingerprint:  511A C9AC EC2F 2372 BBBE E05D 1B99 3C94 1BE9 1FF0
  Key Name:         SUSE:CA OBS Project <SUSE:CA@build.opensuse.org>
  Key Algorithm:    RSA 4096
  Key Created:      Fri Feb 24 12:52:37 2023
  Key Expires:      Sun May  4 12:52:36 2025
  Rpm Name:         gpg-pubkey-1be91ff0-63f8b315



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
.done]
Forcing building of repository cache
Building repository 'opensuse-ca' cache [....done]
All repositories have been refreshed.
```