### PR TITLE
Introduce fleet that prepare EIB deployed Helm charts for 3.1 migration

### DIFF
--- a/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/fleet.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: cattle-system

--- a/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/migration-prep-script.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/migration-prep-script.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: migration-prep-script
+type: Opaque
+stringData:
+  prepare_chart_migration.sh: |
+    #!/bin/sh
+    set -eo pipefail
+
+    manifest_dir_path=
+    config_path=
+
+    runOnNode() {
+        chroot /host "$@" 
+    }
+
+    setupPaths() {
+        if runOnNode test -d "/etc/rancher/rke2/"; then
+            manifest_dir_path=/var/lib/rancher/rke2/server/manifests
+            config_path=/etc/rancher/rke2/config.yaml
+        elif runOnNode test -d "/etc/rancher/k3s/"; then
+            manifest_dir_path=/var/lib/rancher/k3s/server/manifests
+            config_path=/etc/rancher/k3s/config.yaml
+        else 
+            echo "Unknown Kubernetes distribution, '/etc/rancher/rke2/' or '/etc/rancher/k3s/' configuration directories not found."
+            exit 1
+        fi
+    }
+
+    backupManifest() {
+        backup_manifest=${1}
+
+        if [ -z "${MANIFEST_BACKUP_DIR}" ]; then
+            date_suffix=$(date +"%Y%m%d%H%M")
+            backup_location=/tmp/eib-chart-manifests-backup-${date_suffix}
+            runOnNode mkdir -p ${backup_location}
+        else
+            if runOnNode test ! -d "${MANIFEST_BACKUP_DIR}"; then
+                runOnNode mkdir -p ${MANIFEST_BACKUP_DIR}
+            fi
+
+            backup_location=${MANIFEST_BACKUP_DIR}
+        fi
+
+        echo "Backing up ${backup_manifest} under ${backup_location}"
+        runOnNode cp ${backup_manifest} ${backup_location}
+    }
+
+    isInitialiser() {
+        # HelmChart manifests are located on the initialiser node, so the script must
+        # first determine whether it is running in a Pod that is on the initialiser node.
+        echo "Determining whether current node is an initialiser node."
+
+        if runOnNode test ! -f "${config_path}"; then
+            # A missing config.yaml file would indicate that this is a single-node cluster.
+            # Otherwise the config.yaml file would hold configuration (e.g. related to HA setups, or single-node setup).
+            echo "${config_path} missing, assuming that this is a single-node cluster"
+            return 0
+        fi
+
+        if runOnNode grep -q "server:" ${config_path}; then
+            # A config.yaml file containing the 'server' configuration would indicate that this is an
+            # additional node added to a HA cluster setup. Hence not the initialiser node.
+            echo "Non-initialiser node detected."
+            return 1
+        fi
+
+        # If the config.yaml file exists and does not hold the 'server' configuration, then this
+        # is either a single-node server with some configurations, or an initialiser node of an 
+        # HA cluster setup. In both cases, the node can be treated as an initialiser.
+        echo "Initialiser node detected."
+        return 0
+    }
+
+    removeHelmChartManifests() {
+        date_suffix=$(date +"%Y%m%d%H%M")
+        cluster_helmcharts=/tmp/cluster_helm_charts_$date_suffix.txt
+
+        # Custom output columns for the 'kubectl get helmcharts -A' command
+        custom_columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name'
+
+        # Output file for the 'kubectl get helmcharts -A' command
+        helmcharts_file="helmcharts.txt"
+
+        # Annotation added by EIB to each chart it deploys
+        eib_annotation='"edge.suse.com/source":"edge-image-builder"'
+
+        # Get all helmcharts in the cluster and print their namespace and name only
+        kubectl get helmcharts -A -o custom-columns="$custom_columns" --no-headers | tr -s ' ' > $cluster_helmcharts
+        trap "rm $cluster_helmcharts" EXIT
+
+        echo "Searching for HelmCharts deployed by EIB.."
+        while read -r namespace name; do
+            get_annotations_cmd=$(kubectl get helmchart "$name" -n "$namespace" -o jsonpath='{.metadata.annotations}')
+              case "$get_annotations_cmd" in
+                *"$eib_annotation"*)
+                    chart_manifest_path=$manifest_dir_path/$name.yaml
+
+                    if runOnNode test ! -f "$chart_manifest_path"; then
+                        echo "EIB deployed HelmChart $namespace/$name does not have a manifest file under $manifest_dir_path. Skipping.."
+                        continue
+                    fi
+
+                    backupManifest $chart_manifest_path
+                    echo "Removing manifest file for HelmChart $name located under $manifest_dir_path.."
+                    runOnNode rm $chart_manifest_path
+                    ;;
+                *)
+                    echo "HelmChart $namespace/$name is not deployed by EIB. Skipping.."
+                    ;;
+              esac
+        done < $cluster_helmcharts
+    }
+
+    main() {
+        setupPaths
+
+        if ! isInitialiser; then
+            # Non-initialiser nodes do not hold the HelmChart manifests
+            # that need to be upgraded, hence we conclude the script's excecution.
+            exit 0
+        fi
+
+        removeHelmChartManifests
+    }
+
+    main

--- a/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
@@ -1,0 +1,37 @@
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: eib-chart-migration-prep
+spec:
+  concurrency: 3
+  nodeSelector:
+    matchExpressions:
+      # Run on all control-plane nodes
+      - {key: node-role.kubernetes.io/control-plane, operator: In, values: ["true"]}
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Equal"
+    value: "true"
+    effect: "NoExecute"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Equal"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/etcd"
+    operator: "Equal"
+    effect: "NoExecute"
+  serviceAccountName: system-upgrade-controller
+  secrets:
+    - name: migration-prep-script
+      path: /host/run/system-upgrade/secrets/migration-prep-script
+  cordon: true
+  # Version of the specific Edge release that this Plan relates to
+  version: "3.1.0"
+  upgrade:
+    image: registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl:1.30.3
+    command: ["/bin/sh", "/host/run/system-upgrade/secrets/migration-prep-script/prepare_chart_migration.sh"]
+    # For when you want to backup your chart
+    # manifest data under a specific directory
+    # 
+    # envs:
+    # - name: MANIFEST_BACKUP_DIR
+    #   value: "/foo/bar"

--- a/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
@@ -23,7 +23,7 @@ spec:
   secrets:
     - name: migration-prep-script
       path: /host/run/system-upgrade/secrets/migration-prep-script
-  cordon: true
+  cordon: false
   # Version of the specific Edge release that this Plan relates to
   version: "3.1.0"
   upgrade:


### PR DESCRIPTION
Introduces a fleet that ships the following resources:

* Script secret - Holds a bash script that does the following:
   * Determines the K8s distribution of the current node
   * Determines whether the node is an `initializer` node
   * If the node is an `initializer` it then proceeds to go through all `HelmChart` resources deployed on the cluster
   * Each `HelmChart` resources is checked if it is deployed by EIB (if it has the `"edge.suse.com/source":"edge-image-builder"` annotation).
   * For all `HelmChart` resources that are determined to be deployed by EIB, the script locates their manifest files (either in `/var/lib/rancher/rke2/server/manifests` or `/var/lib/rancher/k3s/server/manifests`) and proceeds to remove them from the node.
   * In order to support disaster recovery, the script makes a backup of each removed manifest file under the `/tmp` directory. Users can configure this directory through the SUC Plan.
* SUC Plan - deployed for all `control-plane` nodes; ships the above mentioned script. Supports configuration of the `manifest` backup directory.


Tested on:
* Standalone cluster
* 3 `control-plane` cluster

Example logs for pod running on the `initialiser` node and preparing the following EIB charts:
* longhorn
* longhorn-crd
* cdi
* endpoint-copier-operator
* kubevirt
* metallb

```bash
Determining whether current node is an initialiser node.
Initialiser node detected.
Searching for HelmCharts deployed by EIB..
Backing up /var/lib/rancher/rke2/server/manifests/longhorn.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart longhorn located under /var/lib/rancher/rke2/server/manifests..
Backing up /var/lib/rancher/rke2/server/manifests/longhorn-crd.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart longhorn-crd located under /var/lib/rancher/rke2/server/manifests..
Backing up /var/lib/rancher/rke2/server/manifests/cdi.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart cdi located under /var/lib/rancher/rke2/server/manifests..
Backing up /var/lib/rancher/rke2/server/manifests/endpoint-copier-operator.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart endpoint-copier-operator located under /var/lib/rancher/rke2/server/manifests..
Backing up /var/lib/rancher/rke2/server/manifests/kubevirt.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart kubevirt located under /var/lib/rancher/rke2/server/manifests..
Backing up /var/lib/rancher/rke2/server/manifests/metallb.yaml under /tmp/eib-chart-manifests-backup-202410021613
Removing manifest file for HelmChart metallb located under /var/lib/rancher/rke2/server/manifests..
HelmChart kube-system/rke2-cilium is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-coredns is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-ingress-nginx is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-metrics-server is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-multus is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-snapshot-controller is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-snapshot-controller-crd is not deployed by EIB. Skipping..
HelmChart kube-system/rke2-snapshot-validation-webhook is not deployed by EIB. Skipping..
```

Example logs for pod running on a non-initialiser node:

```bash
Determining whether current node is an initialiser node.
Non-initialiser node detected.
```

Example file structure of the `/var/lib/rancher/rke2/server/manifests` **before** the script has run:

```bash
.
├── cdi.yaml
├── endpoint-copier-operator.yaml
├── ingress-ippool.yaml
├── ingress-l2-adv.yaml
├── k8s-vip.yaml
├── kubevirt.yaml
├── longhorn-crd.yaml
├── longhorn.yaml
├── metallb.yaml
├── rke2-cilium.yaml
├── rke2-coredns.yaml
├── rke2-ingress-config.yaml
├── rke2-ingress-nginx.yaml
├── rke2-metrics-server.yaml
├── rke2-multus.yaml
├── rke2-snapshot-controller-crd.yaml
├── rke2-snapshot-controller.yaml
└── rke2-snapshot-validation-webhook.yaml

1 directory, 18 files
```

Example file structure of the `/var/lib/rancher/rke2/server/manifests` **after** the script has run:

```bash
.
├── ingress-ippool.yaml
├── ingress-l2-adv.yaml
├── k8s-vip.yaml
├── rke2-cilium.yaml
├── rke2-coredns.yaml
├── rke2-ingress-config.yaml
├── rke2-ingress-nginx.yaml
├── rke2-metrics-server.yaml
├── rke2-multus.yaml
├── rke2-snapshot-controller-crd.yaml
├── rke2-snapshot-controller.yaml
└── rke2-snapshot-validation-webhook.yaml

1 directory, 12 files
```

Example contents for the backup directory:

```bash
cp1rke2:/tmp/eib-chart-manifests-backup-202410021613 # tree
.
├── cdi.yaml
├── endpoint-copier-operator.yaml
├── kubevirt.yaml
├── longhorn-crd.yaml
├── longhorn.yaml
└── metallb.yaml

1 directory, 6 files
```