### PR TITLE
Edge 3.0.3 version bumps

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.28.10+k3s1
+        version: v1.28.13+k3s1
       ---
       # worker upgrade plan
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.28.10+k3s1
+        version: v1.28.13+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-pkg-update/pkg-update-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-pkg-update/pkg-update-bundle.yaml
@@ -33,7 +33,7 @@ spec:
           - name: os-pkg-update
             path: /host/run/system-upgrade/secrets/os-pkg-update
         cordon: true
-        version: "3.0.2"
+        version: "3.0.3"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.5
           command: ["chroot", "/host"]
@@ -55,7 +55,7 @@ spec:
           - name: os-pkg-update
             path: /host/run/system-upgrade/secrets/os-pkg-update
         cordon: true
-        version: "3.0.2"
+        version: "3.0.3"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.5
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.28.10+rke2r1
+        version: v1.28.13+rke2r1
       ---
       # worker upgrade plan
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.28.10+rke2r1
+        version: v1.28.13+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/metal3-chart"
-  version: "0.7.3"
+  version: "0.7.4"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.8.5"
+  version: "2.8.8"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/system-upgrade-controller-plans/eib-chart-upgrade/plan.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-chart-upgrade/plan.yaml
@@ -27,7 +27,7 @@ spec:
       path: /host/run/system-upgrade/secrets/eib-chart-upgrade-user-data
   cordon: true
   # Version of the specific Edge release that this Plan relates to
-  version: "3.0.2"
+  version: "3.0.3"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.5
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-agent.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-agent.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.28.10+k3s1
+  version: v1.28.13+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -25,4 +25,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.28.10+k3s1
+  version: v1.28.13+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-pkg-update/plan-agent.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-pkg-update/plan-agent.yaml
@@ -13,7 +13,7 @@ spec:
     - name: os-pkg-update
       path: /host/run/system-upgrade/secrets/os-pkg-update
   cordon: true
-  version: "3.0.2"
+  version: "3.0.3"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.5
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-pkg-update/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-pkg-update/plan-control-plane.yaml
@@ -24,7 +24,7 @@ spec:
     - name: os-pkg-update
       path: /host/run/system-upgrade/secrets/os-pkg-update
   cordon: true
-  version: "3.0.2"
+  version: "3.0.3"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.5
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-agent.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-agent.yaml
@@ -21,4 +21,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -25,4 +25,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.0.2
+  revision: release-3.0.3
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-pkg-update-gitrepo.yaml
+++ b/gitrepos/day2/os-pkg-update-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-pkg-update
   namespace: fleet-default
 spec:
-  revision: release-3.0.2
+  revision: release-3.0.3
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-pkg-update
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.0.2
+  revision: release-3.0.3
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.0.2
+  revision: release-3.0.3
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,5 +4,5 @@ edge/cdi-chart:0.3.0
 edge/endpoint-copier-operator-chart:0.2.0
 edge/kubevirt-chart:0.3.0
 edge/kubevirt-dashboard-extension-chart:1.0.0
-edge/metal3-chart:0.7.3
+edge/metal3-chart:0.7.4
 edge/metallb-chart:0.14.3

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -5,7 +5,7 @@ edge/akri-onvif-discovery-handler:v0.12.20
 edge/akri-opcua-discovery-handler:v0.12.20
 edge/akri-udev-discovery-handler:v0.12.20
 edge/akri-webhook-configuration:v0.12.20
-edge/baremetal-operator:0.5.1
+edge/baremetal-operator:0.5.2
 edge/cluster-api-controller:v1.6.2
 edge/ip-address-manager:1.6.0
 edge/cluster-api-provider-metal3:v1.6.0
@@ -16,8 +16,8 @@ edge/endpoint-copier-operator:v0.2.0
 edge/frr:8.4
 edge/frr-k8s:v0.0.8
 edge/ip-address-manager:v1.6.0
-edge/ironic:23.0.2.1
-edge/ironic-ipa-downloader:1.3.4
+edge/ironic:23.0.3.1
+edge/ironic-ipa-downloader:1.3.5
 edge/kube-rbac-proxy:v0.14.2
 edge/mariadb:10.6.15.1
 edge/metallb-controller:v0.14.3

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.28.10%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.28.13%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
- [x] Rancher `2.8.5` -> `2.8.8`
- [x] RKE2 `v1.28.10+rke2r1` -> `v1.28.13+rke2r1`
- [x] K3s `v1.28.10+k3s1` -> `v1.28.13+k3s1`
- [x] Metal3 chart `0.7.3` -> `0.7.4`
- [x] BMO `0.5.1` -> `0.5.2`
- [x] Ironic `23.0.2.1` -> `23.0.3.1`
- [x] ironic-ipa-downloader `1.3.4` -> `1.3.5`
- [x] Bump OS and EIB chart upgrade fleets `3.0.2` -> `3.0.3`
- [x] Bump GitRepo revisions `release-3.0.2` -> `release-3.0.3`