### PR TITLE
Edge 3.1.1 version bumps

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.30.3+k3s1
+        version: v1.30.5+k3s1
       ---
       # SUC Plan related to upgrading the K3s version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.30.3+k3s1
+        version: v1.30.5+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -26,7 +26,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.1.0"
+        version: "3.1.1"
         prepare:
           image: registry.suse.com/edge/3.1/kubectl:1.30.3
           command: ["/bin/sh", "-c"]
@@ -94,7 +94,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.1.0"
+        version: "3.1.1"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.6
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.30.3+rke2r1
+        version: v1.30.5+rke2r1
       ---
       # SUC Plan related to upgrading the RKE2 version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.30.3+rke2r1
+        version: v1.30.5+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/3.1/metal3-chart"
-  version: "0.8.1"
+  version: "0.8.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-crd"
   chart: "neuvector-crd"
   repo: "https://charts.rancher.io"
-  version: "104.0.1+up2.7.9"
+  version: "104.0.2+up2.8.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector-ui-extension/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-ui-extension/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-ui-ext"
   chart: "neuvector-ui-ext"
   repo: "https://github.com/rancher/ui-plugin-charts/raw/main/"
-  version: "1.0.0"
+  version: "2.0.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector"
   chart: "neuvector"
   repo: "https://charts.rancher.io"
-  version: "104.0.1+up2.7.9"
+  version: "104.0.2+up2.8.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles-airgap-resources
   chart: "oci://registry.suse.com/edge/3.1/rancher-turtles-airgap-resources-chart"
-  version: "0.3.2"
+  version: "0.3.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles
   chart: "oci://registry.suse.com/edge/3.1/rancher-turtles-chart"
-  version: "0.3.2"
+  version: "0.3.3"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.9.1"
+  version: "2.9.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/eib-charts-migration-prep/plan.yaml
@@ -25,7 +25,7 @@ spec:
       path: /host/run/system-upgrade/secrets/migration-prep-script
   cordon: false
   # Version of the specific Edge release that this Plan relates to
-  version: "3.1.0"
+  version: "3.1.1"
   upgrade:
     image: registry.suse.com/edge/3.1/kubectl:1.30.3
     command: ["/bin/sh", "/host/run/system-upgrade/secrets/migration-prep-script/prepare_chart_migration.sh"]

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.30.3+k3s1
+  version: v1.30.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.30.3+k3s1
+  version: v1.30.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
@@ -28,7 +28,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.1.0"
+  version: "3.1.1"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.6
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
@@ -17,7 +17,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.1.0"
+  version: "3.1.1"
   prepare:
     image: registry.suse.com/edge/3.1/kubectl:1.30.3
     command: ["/bin/sh", "-c"]

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.30.3+rke2r1
+  version: v1.30.5+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
@@ -22,4 +22,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.30.3+rke2r1
+  version: v1.30.5+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.1.0
+  revision: release-3.1.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/os-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.1.0
+  revision: release-3.1.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.1.0
+  revision: release-3.1.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.1.0
+  revision: release-3.1.1
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/3.1/cdi-chart:0.4.0
 edge/3.1/endpoint-copier-operator-chart:0.2.1
 edge/3.1/kubevirt-chart:0.4.0
 edge/3.1/kubevirt-dashboard-extension-chart:1.1.0
-edge/3.1/metal3-chart:0.8.1
+edge/3.1/metal3-chart:0.8.3
 edge/3.1/metallb-chart:0.14.9
 edge/3.1/sriov-crd-chart:1.3.0
 edge/3.1/sriov-network-operator-chart:1.3.0

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -8,6 +8,6 @@ edge/3.1/metal3-chart:0.8.3
 edge/3.1/metallb-chart:0.14.9
 edge/3.1/sriov-crd-chart:1.3.0
 edge/3.1/sriov-network-operator-chart:1.3.0
-edge/3.1/rancher-turtles-chart:0.3.2
-edge/3.1/rancher-turtles-airgap-resources-chart:0.3.2
+edge/3.1/rancher-turtles-chart:0.3.3
+edge/3.1/rancher-turtles-airgap-resources-chart:0.3.3
 edge/3.1/upgrade-controller-chart:0.1.0 

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -9,8 +9,8 @@ edge/3.1/baremetal-operator:0.6.2
 edge/3.1/cluster-api-controller:v1.7.5
 edge/3.1/ip-address-manager:1.7.1
 edge/3.1/cluster-api-provider-metal3:v1.7.1
-edge/3.1/cluster-api-provider-rke2-bootstrap:0.7.0
-edge/3.1/cluster-api-provider-rke2-controlplane:0.7.0
+edge/3.1/cluster-api-provider-rke2-bootstrap:0.7.1
+edge/3.1/cluster-api-provider-rke2-controlplane:0.7.1
 edge/3.1/edge-image-builder:1.1.0
 edge/3.1/endpoint-copier-operator:0.2.0
 edge/3.1/frr:8.4

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -5,7 +5,7 @@ edge/3.1/akri-onvif-discovery-handler:v0.12.20
 edge/3.1/akri-opcua-discovery-handler:v0.12.20
 edge/3.1/akri-udev-discovery-handler:v0.12.20
 edge/3.1/akri-webhook-configuration:v0.12.20
-edge/3.1/baremetal-operator:0.6.1
+edge/3.1/baremetal-operator:0.6.2
 edge/3.1/cluster-api-controller:v1.7.5
 edge/3.1/ip-address-manager:1.7.1
 edge/3.1/cluster-api-provider-metal3:v1.7.1
@@ -15,8 +15,8 @@ edge/3.1/edge-image-builder:1.1.0
 edge/3.1/endpoint-copier-operator:0.2.0
 edge/3.1/frr:8.4
 edge/3.1/frr-k8s:v0.0.14
-edge/3.1/ironic:24.1.2.0
-edge/3.1/ironic-ipa-downloader:2.0.0
+edge/3.1/ironic:24.1.3.0
+edge/3.1/ironic-ipa-downloader:2.0.1
 edge/3.1/kube-rbac-proxy:v0.18.0
 edge/mariadb:10.6.15.1
 edge/3.1/metallb-controller:v0.14.8

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -37,4 +37,4 @@ suse/sles/15.6/virt-exportproxy:1.3.1-150600.5.9.1
 suse/sles/15.6/virt-exportserver:1.3.1-150600.5.9.1
 edge/3.1/upgrade-controller:0.1.0
 edge/3.1/kubectl:1.30.3
-edge/3.1/release-manifest:3.1.0
+edge/3.1/release-manifest:3.1.1

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.30.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.30.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
- [x] Rancher `2.9.1` -> `2.9.3`
- [x] RKE2 `v1.30.3+rke2r1` -> `v1.30.5+rke2r1`
- [x] K3s `v1.30.3+k3s1` -> `v1.30.5+k3s1`
- [x] Neuvector `104.0.1+up2.7.9` -> `104.0.2+up2.8.0`
- [x] Neuvector UI extension `1.0.0` -> `2.0.0`
- [x] Metal3 `0.8.1` -> `0.8.3`
- [x] BMO `0.6.1` -> `0.6.2`
- [x] Ironic `24.1.2.0` -> `24.1.3.0`
- [x] IPA `2.0.0` -> `2.0.1`
- [x] Rancher Turtles `0.3.2` -> `0.3.3`
- [x] Rancher Turtles air gapped `0.3.2` -> `0.3.3`
- [x] CAPI RKE2 bootstrap `0.7.0` -> `0.7.1`
- [x] CAPI RKE2 control-plane `0.7.0` -> `0.7.1`
- [x] Bump OS and migration plan versions `3.1.0` -> `3.1.1`
- [x] Bump GitRepo revisions `release-3.1.0` -> `release-3.1.1`
- [x] Bump release-manifest version `3.1.0` -> `3.1.1`
- [x] Rebase naming changes from #37 