### PR TITLE
Bump suc version

### DIFF
--- a/fleets/day2/system-upgrade-controller/fleet.yaml
+++ b/fleets/day2/system-upgrade-controller/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: cattle-system
 helm:
   releaseName: system-upgrade-controller
   chart: "system-upgrade-controller"
-  version: "104.0.0+up0.7.0"
+  version: "105.0.1"
   repo: "https://charts.rancher.io/"
   values:
     global:


### PR DESCRIPTION
Bump SUC to correct version for the Edge 3.2 release, which is `105.0.1` for Rancher `v2.10.1`.