### PR TITLE
Avoid passing the archive directly to kubectl as an argument

### DIFF
--- a/fleets/day2/eib-charts-upgrader/base/secrets/eib-charts-upgrader-script.yaml
+++ b/fleets/day2/eib-charts-upgrader/base/secrets/eib-charts-upgrader-script.yaml
@@ -56,7 +56,9 @@ stringData:
       fi
 
       echo "Patching $name.."
-      if ! kubectl patch helmchart "$name" --type=merge -p "{\"spec\":{\"chartContent\":\"$archive\", \"version\":\"$version\"}}" -n "$namespace"; then
+      patch_file=$(mktemp)
+      echo "{\"spec\":{\"chartContent\":\"$archive\", \"version\":\"$version\"}}" > "$patch_file"
+      if ! kubectl patch helmchart "$name" --type=merge --patch-file="$patch_file" -n "$namespace"; then
         echo "Failed to patch HelmChart $namespace/$name. Skipping.."
         continue
       fi


### PR DESCRIPTION
### **Problem:**

Currently the `chartPatch.sh` script that is utilised by the `eib-chart-upgrader` fleet is patching `HelmChart` resources in the following way:

```bash
kubectl patch helmchart "$name" --type=merge -p "{\"spec\":{\"chartContent\":\"$archive\", \"version\":\"$version\"}}" -n "$namespace"
```

Where `$archive` is the new chart version archive. While this solution works, there are corner-cases where the symbols in the `$archive` template can be so many (e.g. the archive can be very large) that `kubectl` throws the following error:

```bash
/tmp/scripts/chartPatch.sh: line 52: /usr/bin/kubectl: Argument list too long
```

The error is essentially hits the `ARG_MAX` configuration on the system. It is responsible for the maximum size for a single argument.

### **Solution:**

Save the patch command in a file that will then be passed to `kubectl patch` with the `--patch-file=` option.

By doing it this way, the actual data of `$archive` will reside in the file itself and not be constrained by the `ARG_MAX` configuration. 

When passing the `--patch-file=` to `kubectl` the above problem will not be hit, as the file will be processed at runtime and will not rely on the `ARG_MAX` config.

### **Tested for:**

This issue was hit on the `rancher-turtles` chart, but for further diligence it was tested against the following charts:

- metal3
- rancher-turtles
- longhorn
- rancher