### PR TITLE
[3.1 Backport] Avoid passing the archive directly to kubectl as an argument (#42)

### DIFF
--- a/fleets/day2/eib-charts-upgrader/base/secrets/eib-charts-upgrader-script.yaml
+++ b/fleets/day2/eib-charts-upgrader/base/secrets/eib-charts-upgrader-script.yaml
@@ -56,7 +56,9 @@ stringData:
       fi
 
       echo "Patching $name.."
-      if ! kubectl patch helmchart "$name" --type=merge -p "{\"spec\":{\"chartContent\":\"$archive\", \"version\":\"$version\"}}" -n "$namespace"; then
+      patch_file=$(mktemp)
+      echo "{\"spec\":{\"chartContent\":\"$archive\", \"version\":\"$version\"}}" > "$patch_file"
+      if ! kubectl patch helmchart "$name" --type=merge --patch-file="$patch_file" -n "$namespace"; then
         echo "Failed to patch HelmChart $namespace/$name. Skipping.."
         continue
       fi


### PR DESCRIPTION
Backport of #42 to Edge `3.1`.