### PR TITLE
Edge 3.2.1 version bumps

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.31.3+k3s1
+        version: v1.31.5+k3s1
       ---
       # SUC Plan related to upgrading the K3s version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.31.3+k3s1
+        version: v1.31.5+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -26,7 +26,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.2.0"
+        version: "3.2.1"
         prepare:
           image: registry.suse.com/edge/3.2/kubectl:1.30.3
           command: ["/bin/sh", "-c"]
@@ -94,7 +94,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.2.0"
+        version: "3.2.1"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.6
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.31.3+rke2r1
+        version: v1.31.5+rke2r1
       ---
       # SUC Plan related to upgrading the RKE2 version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.31.3+rke2r1
+        version: v1.31.5+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/longhorn/longhorn-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/longhorn/longhorn-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "longhorn-crd"
   chart: "longhorn-crd"
   repo: "https://charts.rancher.io/"
-  version: "105.1.0+up1.7.2"
+  version: "105.1.1+up1.7.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
+++ b/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "longhorn"
   chart: "longhorn"
   repo: "https://charts.rancher.io/"
-  version: "105.1.0+up1.7.2"
+  version: "105.1.1+up1.7.3"
   takeOwnership: true
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/3.2/metal3-chart"
-  version: "302.0.0+up0.9.0"
+  version: "302.0.0+up0.9.4"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/3.2/metal3-chart"
-  version: "302.0.0+up0.9.4"
+  version: "302.0.1+up0.9.4"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/metallb/fleet.yaml
+++ b/fleets/day2/chart-templates/metallb/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: metallb-system
 helm:
   releaseName: metallb
   chart: "oci://registry.suse.com/edge/3.2/metallb-chart"
-  version: "302.0.0+up0.14.9"
+  version: "302.0.1+up0.14.9"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-crd"
   chart: "neuvector-crd"
   repo: "https://charts.rancher.io"
-  version: "105.0.0+up2.8.3"
+  version: "105.0.1+up2.8.4"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector"
   chart: "neuvector"
   repo: "https://charts.rancher.io"
-  version: "105.0.0+up2.8.3"
+  version: "105.0.1+up2.8.4"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -7,3 +7,24 @@ helm:
   version: "105.0.1+up2.8.4"
   # custom chart value overrides
   values: {}
+
+diff:
+  comparePatches:
+  - apiVersion: batch/v1
+    kind: CronJob
+    name: neuvector-cert-upgrader-pod
+    namespace: neuvector-system
+    operations:
+    - {"op":"remove", "path":"/metadata/annotations/cert-upgrader-uid"}
+  - apiVersion: coordination.k8s.io/v1
+    kind: Lease
+    name: neuvector-cert-upgrader
+    namespace: neuvector-system
+    operations:
+    - {"op":"remove", "path":"/spec/leaseTransitions"}
+  - apiVersion: coordination.k8s.io/v1
+    kind: Lease
+    name: neuvector-controller
+    namespace: neuvector-system
+    operations:
+    - {"op":"remove", "path":"/spec/leaseTransitions"}

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.10.1"
+  version: "2.10.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.3+k3s1
+  version: v1.31.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.3+k3s1
+  version: v1.31.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
@@ -28,7 +28,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.2.0"
+  version: "3.2.1"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.6
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
@@ -17,7 +17,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.2.0"
+  version: "3.2.1"
   prepare:
     image: registry.suse.com/edge/3.2/kubectl:1.30.3
     command: ["/bin/sh", "-c"]

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.31.3+rke2r1
+  version: v1.31.5+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
@@ -22,4 +22,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.31.3+rke2r1
+  version: v1.31.5+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.2.0
+  revision: release-3.2.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/os-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.2.0
+  revision: release-3.2.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.2.0
+  revision: release-3.2.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.2.0
+  revision: release-3.2.1
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/3.2/cdi-chart:302.0.0+up0.4.0
 edge/3.2/endpoint-copier-operator-chart:302.0.0+up0.2.1
 edge/3.2/kubevirt-chart:302.0.0+up0.4.0
 edge/3.2/kubevirt-dashboard-extension-chart:302.0.0+up1.2.1
-edge/3.2/metal3-chart:302.0.0+up0.9.4
+edge/3.2/metal3-chart:302.0.1+up0.9.4
 edge/3.2/metallb-chart:302.0.1+up0.14.9
 edge/3.2/sriov-crd-chart:302.0.0+up1.4.0
 edge/3.2/sriov-network-operator-chart:302.0.0+up1.4.0

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/3.2/cdi-chart:302.0.0+up0.4.0
 edge/3.2/endpoint-copier-operator-chart:302.0.0+up0.2.1
 edge/3.2/kubevirt-chart:302.0.0+up0.4.0
 edge/3.2/kubevirt-dashboard-extension-chart:302.0.0+up1.2.1
-edge/3.2/metal3-chart:302.0.0+up0.9.0
+edge/3.2/metal3-chart:302.0.0+up0.9.4
 edge/3.2/metallb-chart:302.0.1+up0.14.9
 edge/3.2/sriov-crd-chart:302.0.0+up1.4.0
 edge/3.2/sriov-network-operator-chart:302.0.0+up1.4.0

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -5,7 +5,7 @@ edge/3.2/endpoint-copier-operator-chart:302.0.0+up0.2.1
 edge/3.2/kubevirt-chart:302.0.0+up0.4.0
 edge/3.2/kubevirt-dashboard-extension-chart:302.0.0+up1.2.1
 edge/3.2/metal3-chart:302.0.0+up0.9.0
-edge/3.2/metallb-chart:302.0.0+up0.14.9
+edge/3.2/metallb-chart:302.0.1+up0.14.9
 edge/3.2/sriov-crd-chart:302.0.0+up1.4.0
 edge/3.2/sriov-network-operator-chart:302.0.0+up1.4.0
 edge/3.2/rancher-turtles-chart:302.0.0+up0.14.1

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -32,4 +32,4 @@ suse/sles/15.6/virt-exportproxy:1.3.1-150600.5.9.1
 suse/sles/15.6/virt-exportserver:1.3.1-150600.5.9.1
 edge/3.2/upgrade-controller:0.1.1
 edge/3.2/kubectl:1.30.3
-edge/3.2/release-manifest:3.2.0
+edge/3.2/release-manifest:3.2.1

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -10,8 +10,8 @@ edge/3.2/edge-image-builder:1.1.0
 edge/3.2/endpoint-copier-operator:0.2.0
 edge/3.2/frr:8.4
 edge/3.2/frr-k8s:v0.0.14
-edge/3.2/ironic:26.1.2.0
-edge/3.2/ironic-ipa-downloader:3.0.0
+edge/3.2/ironic:26.1.2.3
+edge/3.2/ironic-ipa-downloader:3.0.1
 edge/3.2/kube-rbac-proxy:0.18.1
 edge/mariadb:10.6.15.1
 edge/3.2/metallb-controller:v0.14.8

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.31.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.31.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
Edge 3.2.1 version bumps:

**Kubernetes:**
RKE2 - `v1.31.3+rke2r1` -> `v1.31.5+rke2r1`
K3s - `v1.31.3+k3s1` -> `v1.31.5+k3s1`

**Charts:**
Rancher - `2.10.1` -> `2.10.3`
Longhorn - `105.1.0+up1.7.2` -> `105.1.1+up1.7.3`
Metal3 - `302.0.0+up0.9.0` -> `302.0.1+up0.9.4`
MetalLB - `302.0.0+up0.14.9` -> `302.0.1+up0.14.9`
Neuvector - `105.0.0+up2.8.3` -> `105.0.1+up2.8.4`

**Images:**
Ironic - `26.1.2.0` -> `26.1.2.3`
IPA - `3.0.0` -> `3.0.1`
Release Manifest - `3.2.0` -> `3.2.1`