### PR TITLE
[3.3.1] - version bumps

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.32.3+k3s1
+        version: v1.32.4+k3s1
       ---
       # SUC Plan related to upgrading the K3s version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.32.3+k3s1
+        version: v1.32.4+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -26,9 +26,9 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.3.0"
+        version: "3.3.1"
         prepare:
-          image: registry.suse.com/edge/3.3/kubectl:1.30.3
+          image: registry.suse.com/edge/3.3/kubectl:1.32.4
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -94,7 +94,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.3.0"
+        version: "3.3.1"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.6
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.32.3+rke2r1
+        version: v1.32.4+rke2r1
       ---
       # SUC Plan related to upgrading the RKE2 version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.32.3+rke2r1
+        version: v1.32.4+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "303.0.5+up0.11.3"
+  version: "303.0.7+up0.11.5"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-crd"
   chart: "neuvector-crd"
   repo: "https://charts.rancher.io"
-  version: "106.0.0+up2.8.5"
+  version: "106.0.1+up2.8.6"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "neuvector"
   chart: "neuvector"
   repo: "https://charts.rancher.io"
-  version: "106.0.0+up2.8.5"
+  version: "106.0.1+up2.8.6"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles-airgap-resources
   chart: "oci://registry.suse.com/edge/charts/rancher-turtles-airgap-resources"
-  version: "303.0.2+up0.19.0"
+  version: "303.0.4+up0.20.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles
   chart: "oci://registry.suse.com/edge/charts/rancher-turtles"
-  version: "303.0.2+up0.19.0"
+  version: "303.0.4+up0.20.0"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.11.1"
+  version: "2.11.2"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/eib-charts-upgrader/base/job.yaml
+++ b/fleets/day2/eib-charts-upgrader/base/job.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: eib-charts-upgrader
       containers:
       - name: kubectl-container
-        image: registry.suse.com/edge/3.3/kubectl:1.30.3
+        image: registry.suse.com/edge/3.3/kubectl:1.32.4
         command: ["/bin/sh", "-c"]
         args: ["/tmp/scripts/chartPatch.sh"]
         volumeMounts:

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.3+k3s1
+  version: v1.32.4+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.3+k3s1
+  version: v1.32.4+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
@@ -28,7 +28,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.3.0"
+  version: "3.3.1"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.6
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
@@ -17,9 +17,9 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.3.0"
+  version: "3.3.1"
   prepare:
-    image: registry.suse.com/edge/3.3/kubectl:1.30.3
+    image: registry.suse.com/edge/3.3/kubectl:1.32.4
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.32.3+rke2r1
+  version: v1.32.4+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
@@ -22,4 +22,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.32.3+rke2r1
+  version: v1.32.4+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.0
+  revision: release-3.3.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/os-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.0
+  revision: release-3.3.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.0
+  revision: release-3.3.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.3.0
+  revision: release-3.3.1
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,10 +4,10 @@ edge/charts/cdi:303.0.0+up0.5.0
 edge/charts/endpoint-copier-operator:303.0.0+up0.2.1
 edge/charts/kubevirt:303.0.0+up0.5.0
 edge/charts/kubevirt-dashboard-extension:303.0.2+up1.3.2
-edge/charts/metal3:303.0.5+up0.11.3
+edge/charts/metal3:303.0.7+up0.11.5
 edge/charts/metallb:303.0.0+up0.14.9
 edge/charts/sriov-crd:303.0.2+up1.5.0
 edge/charts/sriov-network-operator:303.0.2+up1.5.0
-edge/charts/rancher-turtles:303.0.0+up0.19.0
-edge/charts/rancher-turtles-airgap-resources:303.0.0+up0.19.0
-edge/charts/upgrade-controller:303.0.0+up0.1.1
+edge/charts/rancher-turtles:303.0.4+up0.20.0
+edge/charts/rancher-turtles-airgap-resources:303.0.4+up0.20.0
+edge/charts/upgrade-controller:303.0.1+up0.1.1

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -5,14 +5,14 @@ edge/3.3/akri-onvif-discovery-handler:v0.12.20
 edge/3.3/akri-opcua-discovery-handler:v0.12.20
 edge/3.3/akri-udev-discovery-handler:v0.12.20
 edge/3.3/akri-webhook-configuration:v0.12.20
-edge/3.3/baremetal-operator:0.9.1
-edge/3.3/edge-image-builder:1.2.0
+edge/3.3/baremetal-operator:0.9.1.1
+edge/3.3/edge-image-builder:1.2.1
 edge/3.3/endpoint-copier-operator:0.2.0
 edge/3.3/frr:8.5.6
 edge/3.3/frr-k8s:v0.0.16
 edge/3.3/ironic:26.1.2.4
-edge/3.3/ironic-ipa-downloader:3.0.6
-edge/3.3/kube-rbac-proxy:0.18.2
+edge/3.3/ironic-ipa-downloader:3.0.7
+edge/3.3/kube-rbac-proxy:0.18.1
 edge/mariadb:10.6.15.1
 edge/3.3/metallb-controller:v0.14.9
 edge/3.3/metallb-speaker:v0.14.9
@@ -31,5 +31,5 @@ suse/sles/15.6/virt-api:1.4.0-150600.5.15.1
 suse/sles/15.6/virt-exportproxy:1.4.0-150600.5.15.1
 suse/sles/15.6/virt-exportserver:1.4.0-150600.5.15.1
 edge/3.3/upgrade-controller:0.1.1
-edge/3.3/kubectl:1.30.3
-edge/3.3/release-manifest:3.3.0
+edge/3.3/kubectl:1.32.4
+edge/3.3/release-manifest:3.3.1

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
Infrastructure:

 K3s v1.32.3+k3s1 -> v1.32.4+k3s1
 RKE2 v1.32.3+rke2r1 -> v1.32.4+rke2r1
 Bump OS SUC Plan versions to 3.3.1
Charts:

 Bump all chart references to edge/3.3/
 Bump all charts to the new names without -chart suffix convention
 Metal3 303.0.5+up0.11.3 -> 303.0.7+up0.11.5
 Neuvector 106.0.0+up2.8.5 -> 106.0.1+up2.8.6
 Rancher Turtles Air Gapped Resources 303.0.2+up0.19.0 -> 303.0.4+up0.20.0
 Rancher Turtles 303.0.2+up0.19.0 -> 303.0.4+up0.20.0
 Rancher 2.11.1 -> 2.11.2
Images:

 Bump all image references to edge/3.3/
 BMO 0.9.1 -> 0.9.1.1
 edge-image-builder 1.2.0 -> 1.2.1
 ironic-ipa-downloader 3.0.6 -> 3.0.7
 kubectl 1.30.3 -> 1.32.4
 Relseas Manifest 3.3.0 -> 3.3.1
Other:

 Bump GitRepo revisions to release-3.3.1