### PR TITLE
[3.3.2] - version bumps

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.32.4+k3s1
+        version: v1.32.5+k3s1
       ---
       # SUC Plan related to upgrading the K3s version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.32.4+k3s1
+        version: v1.32.5+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -26,7 +26,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.3.1"
+        version: "3.3.2"
         prepare:
           image: registry.suse.com/edge/3.3/kubectl:1.32.4
           command: ["/bin/sh", "-c"]
@@ -94,7 +94,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.3.1"
+        version: "3.3.2"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.6
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.32.4+rke2r1
+        version: v1.32.5+rke2r1
       ---
       # SUC Plan related to upgrading the RKE2 version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.32.4+rke2r1
+        version: v1.32.5+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/longhorn/longhorn-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/longhorn/longhorn-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "longhorn-crd"
   chart: "longhorn-crd"
   repo: "https://charts.rancher.io/"
-  version: "106.2.0+up1.8.1"
+  version: "106.2.1+up1.8.2"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
+++ b/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "longhorn"
   chart: "longhorn"
   repo: "https://charts.rancher.io/"
-  version: "106.2.0+up1.8.1"
+  version: "106.2.1+up1.8.2"
   takeOwnership: true
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-crd"
   chart: "neuvector-crd"
   repo: "https://charts.rancher.io"
-  version: "106.0.1+up2.8.6"
+  version: "106.0.2+up2.8.7"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "neuvector"
   chart: "neuvector"
   repo: "https://charts.rancher.io"
-  version: "106.0.1+up2.8.6"
+  version: "106.0.2+up2.8.7"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles-airgap-resources/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles-airgap-resources
   chart: "oci://registry.suse.com/edge/charts/rancher-turtles-airgap-resources"
-  version: "303.0.4+up0.20.0"
+  version: "303.0.5+up0.21.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: rancher-turtles-system
 helm:
   releaseName: rancher-turtles
   chart: "oci://registry.suse.com/edge/charts/rancher-turtles"
-  version: "303.0.4+up0.20.0"
+  version: "303.0.5+up0.21.0"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.11.2"
+  version: "2.11.3"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.4+k3s1
+  version: v1.32.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.4+k3s1
+  version: v1.32.5+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
@@ -28,7 +28,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.3.1"
+  version: "3.3.2"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.6
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
@@ -17,7 +17,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.3.1"
+  version: "3.3.2"
   prepare:
     image: registry.suse.com/edge/3.3/kubectl:1.32.4
     command: ["/bin/sh", "-c"]

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.32.4+rke2r1
+  version: v1.32.5+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
@@ -22,4 +22,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.32.4+rke2r1
+  version: v1.32.5+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.1
+  revision: release-3.3.2
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/os-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.1
+  revision: release-3.3.2
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.3.1
+  revision: release-3.3.2
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.3.1
+  revision: release-3.3.2
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -8,6 +8,6 @@ edge/charts/metal3:303.0.7+up0.11.5
 edge/charts/metallb:303.0.0+up0.14.9
 edge/charts/sriov-crd:303.0.2+up1.5.0
 edge/charts/sriov-network-operator:303.0.2+up1.5.0
-edge/charts/rancher-turtles:303.0.4+up0.20.0
-edge/charts/rancher-turtles-airgap-resources:303.0.4+up0.20.0
+edge/charts/rancher-turtles:303.0.5+up0.21.0
+edge/charts/rancher-turtles-airgap-resources:303.0.5+up0.21.0
 edge/charts/upgrade-controller:303.0.1+up0.1.1

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -32,4 +32,4 @@ suse/sles/15.6/virt-exportproxy:1.4.0-150600.5.15.1
 suse/sles/15.6/virt-exportserver:1.4.0-150600.5.15.1
 edge/3.3/upgrade-controller:0.1.1
 edge/3.3/kubectl:1.32.4
-edge/3.3/release-manifest:3.3.1
+edge/3.3/release-manifest:3.3.2

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.32.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
Infrastructure:
- [x] K3s `v1.32.4+k3s1` -> `v1.32.5+k3s1`
- [x] RKE2 `v1.32.4+rke2r1` -> `v1.32.5+rke2r1`
- [x] Bump OS SUC Plan versions to `3.3.2`

Charts:
- [x] Longhorn `106.2.0+up1.8.1` -> `106.2.1+up1.8.2`
- [x] Neuvector `106.0.1+up2.8.6` -> `106.0.2+up2.8.7`
- [x] Rancher Turtles Air Gapped Resources `303.0.4+up0.20.0` -> `303.0.5+up0.21.0`
- [x] Rancher Turtles `303.0.4+up0.20.0` -> `303.0.5+up0.21.0`
- [x] Rancher `2.11.2` -> `2.11.3`

Images:
- [x] Release Manifest `3.3.1` -> `3.3.2`

Other:
- [x] Bump GitRepo revisions to `release-3.3.2`