### PR TITLE
Avoid passing encoded chart data directly as a literal during secret creation

### DIFF
--- a/scripts/day2/generate-chart-upgrade-data.sh
+++ b/scripts/day2/generate-chart-upgrade-data.sh
@@ -108,10 +108,13 @@ for archive in "$archive_dir"/*.tgz; do
     # Construct the secret literal
     data_str="$chart_name|$chart_version|$base64_encoded_archive"
 
+    secret_file=$(mktemp)
+    echo -n "$data_str" > $secret_file
+
     # Create chart data secret in the 'eib-charts-upgrader' fleet
     secret_name=$(echo $archive_no_ext | tr '.' '-' | tr '+' '-')
     kubectl create secret generic $secret_name \
-    --from-literal=$secret_name.txt="$data_str" \
+    --from-file=$secret_name.txt=$secret_file \
     --dry-run=client -o yaml > $secrets_path/$secret_name.yaml
 
     # Add the script name to the 'eib-charts-upgrader' fleet secret kustomization.yaml


### PR DESCRIPTION
Currently the `generate-chart-upgrade-data.sh` uses the following command to create a secret that will later be the source of truth for the chart update:

```bash
  kubectl create secret generic $secret_name \
    --from-literal=$secret_name.txt="$data_str" \
    --dry-run=client -o yaml > $secrets_path/$secret_name.yaml
```

Where `$data_str` is the upgrade content for a specific chart in the format of `<chart_name>|<chart_version>|<base64_encoded_chart>`. 

Using `--from-literal` causes the `kubectl create` command to exit out with the following error: 

```bash
/usr/bin/kubectl: Argument list too long
```
The error essentially hits the `ARG_MAX` configuration on the system. It is responsible for the maximum size for a single argument.

This PR proposes to not use the `--from-literal`, but instead use the `--from-file` flag. By doing it this way, the actual data of `$data_str` will reside in a temp file and not be constrained by the ARG_MAX configuration.

When passing the `--from-file=` to kubectl the above problem will not be hit, as the temp file will be processed at runtime and will not rely on the `ARG_MAX` config.

**Note:** This needs to be back ported to `3.1`, `3.2` and `3.3` as well.