### PR TITLE
updated chart upgrade script to handle charts with v

### DIFF
--- a/scripts/day2/generate-chart-upgrade-data.sh
+++ b/scripts/day2/generate-chart-upgrade-data.sh
@@ -94,13 +94,13 @@ for archive in "$archive_dir"/*.tgz; do
     archive_no_ext=$(basename "$archive" .tgz)
 
     # Parse chart name from archive name
-    chart_name=$(echo $archive_no_ext | sed -E 's|-[0-9]+\.[0-9]+\.[0-9]+.*||')
+    chart_name=$(echo $archive_no_ext | sed -E 's|-v?[0-9]+\.[0-9]+\.[0-9]+.*||')
     if [[ $chart_name == *"$chart_suffix" ]]; then
         chart_name=${chart_name%$chart_suffix}
     fi
 
     # Parse chart version from archive name
-    chart_version=$(echo $archive_no_ext | sed -E 's|.*-([0-9]+\.[0-9]+\.[0-9]+.*)$|\1|')
+    chart_version=$(echo $archive_no_ext | sed -E 's|.*-(v?[0-9]+\.[0-9]+\.[0-9]+.*)$|\1|')
     
     # Encode the archive itself
     base64_encoded_archive=$(base64 $base64_option "$archive")


### PR DESCRIPTION
- During 3.3.2 → 3.4.0 upgrades, cert-manager stayed at 1.14.2 while Fleet expected 1.18.2, causing validation to fail.
- Fix chart archive parsing to support versions with a leading “v” (e.g., cert-manager-v1.18.2.tgz).
- Ensures the eib-charts-upgrader generates correct secrets and upgrades cert-manager to the expected version.