### PR TITLE
feat: Add 3.6.1 release configuration

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/k3s-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.35.3+k3s1
+        version: v1.35.4+k3s1
       ---
       # SUC Plan related to upgrading the K3s version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -60,7 +60,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/k3s-upgrade
-        version: v1.35.3+k3s1
+        version: v1.35.4+k3s1
     name: k3s-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -26,9 +26,9 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.6.0"
+        version: "3.6.1"
         prepare:
-          image: registry.suse.com/edge/3.6/kubectl:1.35.3
+          image: registry.suse.com/edge/3.6/kubectl:1.35.4
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -94,7 +94,7 @@ spec:
           - name: os-upgrade-script
             path: /host/run/system-upgrade/secrets/os-upgrade-script
         cordon: true
-        version: "3.6.0"
+        version: "3.6.1"
         upgrade:
           image: registry.suse.com/bci/bci-base:15.6
           command: ["chroot", "/host"]

--- a/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/rke2-upgrade/plan-bundle.yaml
@@ -35,7 +35,7 @@ spec:
         cordon: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.35.3+rke2r3
+        version: v1.35.4+rke2r1
       ---
       # SUC Plan related to upgrading the RKE2 version of worker nodes
       apiVersion: upgrade.cattle.io/v1
@@ -62,7 +62,7 @@ spec:
           force: true
         upgrade:
           image: rancher/rke2-upgrade
-        version: v1.35.3+rke2r3
+        version: v1.35.4+rke2r1
     name: rke2-upgrade-bundle.yaml
   targets:
   # Match nothing, user needs to specify targets

--- a/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
+++ b/fleets/day2/chart-templates/longhorn/longhorn/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "longhorn"
   chart: "suse-storage"
   repo: "oci://dp.apps.rancher.io/charts"
-  version: "1.11.1"
+  version: "1.11.2"
   takeOwnership: true
   # custom chart value overrides
   values:

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "306.0.27+up0.15.0"
+  version: "306.0.29+up0.15.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "306.0.26+up0.15.0"
+  version: "306.0.27+up0.15.0"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector-crd/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "neuvector-crd"
   chart: "neuvector-crd"
   repo: "https://charts.rancher.io"
-  version: "109.0.1+up2.8.13"
+  version: "109.0.2+up2.10.2"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
+++ b/fleets/day2/chart-templates/neuvector/neuvector/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   releaseName: "neuvector"
   chart: "neuvector"
   repo: "https://charts.rancher.io"
-  version: "109.0.1+up2.8.13"
+  version: "109.0.2+up2.10.2"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher-turtles-providers/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher-turtles-providers/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: rancher-turtles-providers-system
 helm:
   releaseName: rancher-turtles-providers
   chart: "oci://registry.suse.com/edge/charts/rancher-turtles-providers"
-  version: "306.0.6+up0.26.1"
+  version: "306.0.7+up0.26.2"
   # custom chart value overrides
   values: {}
 

--- a/fleets/day2/chart-templates/rancher/fleet.yaml
+++ b/fleets/day2/chart-templates/rancher/fleet.yaml
@@ -4,6 +4,6 @@ helm:
   releaseName: "rancher"
   chart: "rancher"
   repo: "https://charts.rancher.com/server-charts/prime"
-  version: "2.14.1"
+  version: "2.14.2"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/eib-charts-upgrader/base/job.yaml
+++ b/fleets/day2/eib-charts-upgrader/base/job.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: eib-charts-upgrader
       containers:
       - name: kubectl-container
-        image: registry.suse.com/edge/3.6/kubectl:1.35.3
+        image: registry.suse.com/edge/3.6/kubectl:1.35.4
         command: ["/bin/sh", "-c"]
         args: ["/tmp/scripts/chartPatch.sh"]
         volumeMounts:

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.35.3+k3s1
+  version: v1.35.4+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/k3s-upgrade/plan-worker.yaml
@@ -20,4 +20,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.35.3+k3s1
+  version: v1.35.4+k3s1

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-control-plane.yaml
@@ -28,7 +28,7 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.6.0"
+  version: "3.6.1"
   upgrade:
     image: registry.suse.com/bci/bci-base:15.6
     command: ["chroot", "/host"]

--- a/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/os-upgrade/plan-worker.yaml
@@ -17,9 +17,9 @@ spec:
     - name: os-upgrade-script
       path: /host/run/system-upgrade/secrets/os-upgrade-script
   cordon: true
-  version: "3.6.0"
+  version: "3.6.1"
   prepare:
-    image: registry.suse.com/edge/3.6/kubectl:1.35.3
+    image: registry.suse.com/edge/3.6/kubectl:1.35.4
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-control-plane.yaml
@@ -26,4 +26,4 @@ spec:
   cordon: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.35.3+rke2r3
+  version: v1.35.4+rke2r1

--- a/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
+++ b/fleets/day2/system-upgrade-controller-plans/rke2-upgrade/plan-worker.yaml
@@ -22,4 +22,4 @@ spec:
     force: true
   upgrade:
     image: rancher/rke2-upgrade
-  version: v1.35.3+rke2r3
+  version: v1.35.4+rke2r1

--- a/gitrepos/day2/k3s-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/k3s-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k3s-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.6.0
+  revision: release-3.6.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/k3s-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/os-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/os-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: os-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.6.0
+  revision: release-3.6.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/os-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/rke2-upgrade-gitrepo.yaml
+++ b/gitrepos/day2/rke2-upgrade-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rke2-upgrade
   namespace: fleet-default
 spec:
-  revision: release-3.6.0
+  revision: release-3.6.1
   paths:
   - fleets/day2/system-upgrade-controller-plans/rke2-upgrade
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
+++ b/gitrepos/day2/system-upgrade-controller-gitrepo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: system-upgrade-controller
   namespace: fleet-default
 spec:
-  revision: release-3.6.0
+  revision: release-3.6.1
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -2,9 +2,9 @@ edge/charts/cdi:306.0.2+up0.7.0
 edge/charts/endpoint-copier-operator:306.0.1+up0.3.0
 edge/charts/kubevirt:306.0.2+up0.7.0
 edge/charts/kubevirt-dashboard-extension:306.0.4+up1.3.3
-edge/charts/metal3:306.0.26+up0.15.0
+edge/charts/metal3:306.0.29+up0.15.0
 edge/charts/metallb:306.0.2+up0.15.3
 edge/charts/sriov-crd:306.0.4+up1.6.0
 edge/charts/sriov-network-operator:306.0.4+up1.6.0
-edge/charts/rancher-turtles-providers:306.0.6+up0.26.1
-edge/charts/upgrade-controller:306.0.3+up0.1.3
+edge/charts/rancher-turtles-providers:306.0.7+up0.26.2
+edge/charts/upgrade-controller:306.0.4+up0.1.3

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -3,9 +3,9 @@ edge/3.6/edge-image-builder:1.3.3.1
 edge/3.6/endpoint-copier-operator:0.3.0
 edge/3.6/frr:10.2.1
 edge/3.6/frr-k8s:v0.0.20
-edge/3.6/ironic:35.0.0.1
-edge/3.6/ironic-ipa-downloader:3.1.1
-edge/3.6/kube-rbac-proxy:0.19.1
+edge/3.6/ironic:35.0.0.2
+edge/3.6/ironic-ipa-downloader:3.1.2
+edge/3.6/kube-rbac-proxy:0.20.1
 edge/mariadb:10.6.15.1
 edge/3.6/metallb-controller:v0.15.3
 edge/3.6/metallb-speaker:v0.15.3

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -24,5 +24,5 @@ suse/sles/15.7/virt-api:1.7.0-150700.3.16.2
 suse/sles/15.7/virt-exportproxy:1.7.0-150700.3.16.2
 suse/sles/15.7/virt-exportserver:1.7.0-150700.3.16.2
 edge/3.6/upgrade-controller:0.1.3
-edge/3.6/kubectl:1.35.3
-edge/3.6/release-manifest:3.6.0
+edge/3.6/kubectl:1.35.4
+edge/3.6/release-manifest:3.6.1

--- a/scripts/day2/edge-release-rke2-images.txt
+++ b/scripts/day2/edge-release-rke2-images.txt
@@ -1,6 +1,6 @@
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/sha256sum-amd64.txt
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/rke2.linux-amd64.tar.gz
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/rke2-images.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/rke2-images-core.linux-amd64.tar.zst
-https://github.com/rancher/rke2/releases/download/v1.35.3%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/sha256sum-amd64.txt
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2.linux-amd64.tar.gz
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst
+https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst


### PR DESCRIPTION
Updates component versions to Kubernetes v1.35.4:
- K3S: v1.35.4+k3s1
- RKE2: v1.35.4+rke2r1
- OS version: 3.6.1
- Rancher: 2.14.2
- NeuVector: 109.0.2+up2.10.2
- kubectl: 1.35.4

Updates all system upgrade plans, bundles, GitRepo files, chart templates, and scripts.