### PR TITLE
Update Metal3 and Ironic versions for 3.5.2

### DIFF
--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "305.0.24+up0.13.2"
+  version: "305.0.25+up0.13.2"
   # custom chart value overrides
   values: {}

--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "305.0.25+up0.13.2"
+  version: "305.0.26+up0.13.2"
   # custom chart value overrides
   values: {}

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/charts/cdi:305.0.1+up0.6.0
 edge/charts/endpoint-copier-operator:305.0.1+up0.3.0
 edge/charts/kubevirt:305.0.1+up0.6.0
 edge/charts/kubevirt-dashboard-extension:305.0.4+up1.3.3
-edge/charts/metal3:305.0.24+up0.13.2
+edge/charts/metal3:305.0.25+up0.13.2
 edge/charts/metallb:305.0.1+up0.15.2
 edge/charts/sriov-crd:305.0.4+up1.6.0
 edge/charts/sriov-network-operator:305.0.4+up1.6.0

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/charts/cdi:305.0.1+up0.6.0
 edge/charts/endpoint-copier-operator:305.0.1+up0.3.0
 edge/charts/kubevirt:305.0.1+up0.6.0
 edge/charts/kubevirt-dashboard-extension:305.0.4+up1.3.3
-edge/charts/metal3:305.0.25+up0.13.2
+edge/charts/metal3:305.0.26+up0.13.2
 edge/charts/metallb:305.0.1+up0.15.2
 edge/charts/sriov-crd:305.0.4+up1.6.0
 edge/charts/sriov-network-operator:305.0.4+up1.6.0

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -10,7 +10,7 @@ edge/3.5/edge-image-builder:1.3.3.1
 edge/3.5/endpoint-copier-operator:0.3.0
 edge/3.5/frr:10.2.1
 edge/3.5/frr-k8s:v0.0.20
-edge/3.5/ironic:32.0.0.1
+edge/3.5/ironic:32.0.1.0
 edge/3.5/ironic-ipa-downloader:3.0.11
 edge/3.5/kube-rbac-proxy:0.19.1
 edge/mariadb:10.6.15.1


### PR DESCRIPTION
Updates Metal3 and Ironic versions to match Factory 3.5 branch.

**Changes:**
- Metal3 chart: 305.0.25+up0.13.2 → 305.0.26+up0.13.2
- Ironic image: 32.0.0.1 → 32.0.1.0

**Updated files:**
- fleets/day2/chart-templates/metal3/fleet.yaml
- scripts/day2/edge-release-images.txt
- scripts/day2/edge-release-helm-oci-artefacts.txt