### PR TITLE
Update Metal3, Ironic, and Upgrade Controller for 3.4.4

### DIFF
--- a/fleets/day2/chart-templates/metal3/fleet.yaml
+++ b/fleets/day2/chart-templates/metal3/fleet.yaml
@@ -3,6 +3,6 @@ defaultNamespace: metal3-system
 helm:
   releaseName: metal3
   chart: "oci://registry.suse.com/edge/charts/metal3"
-  version: "304.0.19+up0.12.9"
+  version: "304.0.22+up0.12.9"
   # custom chart value overrides
   values: {}

--- a/scripts/day2/edge-release-helm-oci-artefacts.txt
+++ b/scripts/day2/edge-release-helm-oci-artefacts.txt
@@ -4,7 +4,7 @@ edge/charts/cdi:304.0.1+up0.6.0
 edge/charts/endpoint-copier-operator:304.0.1+up0.3.0
 edge/charts/kubevirt:304.0.1+up0.6.0
 edge/charts/kubevirt-dashboard-extension:304.0.3+up1.3.2
-edge/charts/metal3:304.0.19+up0.12.9
+edge/charts/metal3:304.0.22+up0.12.9
 edge/charts/metallb:304.0.0+up0.14.9
 edge/charts/sriov-crd:304.0.2+up1.5.0
 edge/charts/sriov-network-operator:304.0.2+up1.5.0

--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -10,7 +10,7 @@ edge/3.4/edge-image-builder:1.3.1.1
 edge/3.4/endpoint-copier-operator:0.3.0
 edge/3.4/frr:8.5.6
 edge/3.4/frr-k8s:v0.0.16
-edge/3.4/ironic:29.0.4.4
+edge/3.4/ironic:29.0.6.0
 edge/3.4/ironic-ipa-downloader:3.0.10
 edge/3.4/kube-rbac-proxy:0.18.1
 edge/mariadb:10.6.15.1
@@ -30,6 +30,6 @@ suse/sles/15.7/virt-controller:1.5.2-150700.3.5.2
 suse/sles/15.7/virt-api:1.5.2-150700.3.5.2
 suse/sles/15.7/virt-exportproxy:1.5.2-150700.3.5.2
 suse/sles/15.7/virt-exportserver:1.5.2-150700.3.5.2
-edge/3.4/upgrade-controller:0.1.1
+edge/3.4/upgrade-controller:0.1.3
 edge/3.4/kubectl:1.33.11
 edge/3.4/release-manifest:3.4.4


### PR DESCRIPTION
Updates component versions to align with Factory 3.4 branch for the 3.4.4 release.

**Changes:**
- Metal3 chart: 304.0.19+up0.12.9 → 304.0.22+up0.12.9
- Ironic image: 29.0.4.4 → 29.0.6.0
- Upgrade Controller: 0.1.1 → 0.1.3

**Updated files:**
- fleets/day2/chart-templates/metal3/fleet.yaml
- scripts/day2/edge-release-images.txt
- scripts/day2/edge-release-helm-oci-artefacts.txt

**Related:**
- Factory 3.4 branch: already merged
- Stack Validation MR: https://gitlab.suse.de/edge-engineering/stack-validation/-/merge_requests/1323