### PR TITLE
Update ironic-ipa-downloader to 3.0.12 for 3.4.4

### DIFF
--- a/scripts/day2/edge-release-images.txt
+++ b/scripts/day2/edge-release-images.txt
@@ -11,7 +11,7 @@ edge/3.4/endpoint-copier-operator:0.3.0
 edge/3.4/frr:8.5.6
 edge/3.4/frr-k8s:v0.0.16
 edge/3.4/ironic:29.0.6.0
-edge/3.4/ironic-ipa-downloader:3.0.10
+edge/3.4/ironic-ipa-downloader:3.0.12
 edge/3.4/kube-rbac-proxy:0.18.1
 edge/mariadb:10.6.15.1
 edge/3.4/metallb-controller:v0.14.9


### PR DESCRIPTION
Follow-up to #93 - updates the missing IPA downloader version.

**Changes:**
- ironic-ipa-downloader: 3.0.10 → 3.0.12

Aligns with Factory 3.4 branch release_images.yaml.

**Updated files:**
- scripts/day2/edge-release-images.txt