### PR TITLE
Handle upgrades to SLES

### DIFF
--- a/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
+++ b/bundles/day2/system-upgrade-controller-plans/os-upgrade/os-upgrade-bundle.yaml
@@ -184,7 +184,7 @@ spec:
               # Waits for the background process with pid to finish and propagates its exit code to '$?'
               wait ${BACKGROUND_PROC_PID}
 
-              # Get exit code of backgroup process 
+              # Get exit code of backgroup process
               BACKGROUND_PROC_EXIT=$?
               if [ ${BACKGROUND_PROC_EXIT} -ne 0 ]; then
                   exit ${BACKGROUND_PROC_EXIT}
@@ -194,6 +194,15 @@ spec:
               # Will only be needed when transactional-update has successfully
               # done any package upgrades/updates.
               if [ -f /run/reboot-needed ]; then
+                  # Disable firewalld if migrating to SLES (ID="sles")
+                  # SLES 16.1 enables firewalld by default, which blocks RKE2 ports
+                  # SL Micro has firewalld disabled, so we only need to disable it for SLES
+                  if /usr/sbin/transactional-update --continue run sh -c 'grep -q "^ID=\"sles\"" /etc/os-release'; then
+                      echo "Target OS is SLES - disabling firewalld in new snapshot..."
+                      /usr/sbin/transactional-update --continue run systemctl disable firewalld.service || true
+                      /usr/sbin/transactional-update --continue run systemctl mask firewalld.service || true
+                  fi
+
                   # Create a placeholder indicating that the os upgrade
                   # has finished succesfully
                   touch ${OS_UPGRADED_PLACEHOLDER_PATH}


### PR DESCRIPTION
On SLES distros the firewalld is enabled by default which blocks the CNIs from working propperly.
This change will disable the systemd firewalld service which will make it compatible with the SL Micro distros